### PR TITLE
run npm prune after packages installation

### DIFF
--- a/lib/build.sh
+++ b/lib/build.sh
@@ -183,6 +183,8 @@ function build_dependencies() {
       npm --unsafe-perm prune 2>&1 | indent
       info "Installing any new modules"
       npm install --unsafe-perm --quiet --userconfig $build_dir/.npmrc 2>&1 | indent
+      info "Pruning possible devDependencies installed in previous step"
+      npm --unsafe-perm --prod prune 2>&1 | indent
     else
       info "$cache_status"
       info "Installing node modules"


### PR DESCRIPTION
because `npm-shrinkwrap.json` can contain `devDependencies`, run `npm prune` after the `npm install` too in order to remove these