### PR TITLE
Revert "run npm prune after packages installation"

### DIFF
--- a/lib/build.sh
+++ b/lib/build.sh
@@ -183,8 +183,6 @@ function build_dependencies() {
       npm --unsafe-perm prune 2>&1 | indent
       info "Installing any new modules"
       npm install --unsafe-perm --quiet --userconfig $build_dir/.npmrc 2>&1 | indent
-      info "Pruning possible devDependencies installed in previous step"
-      npm --unsafe-perm --prod prune 2>&1 | indent
     else
       info "$cache_status"
       info "Installing node modules"


### PR DESCRIPTION
Reverts apiaryio/heroku-buildpack-nodejs-grunt#9

Because `webpack` and maybe also some others maybe too :-1: 